### PR TITLE
fixup! diagram_test.cc

### DIFF
--- a/systems/framework/system.h
+++ b/systems/framework/system.h
@@ -1441,27 +1441,6 @@ class System : public SystemBase {
       Event<T>* event,
       CompositeEventCollection<T>* events) const = 0;
 
-  /** (Internal use only) */
-  const EventCollection<PublishEvent<T>>&
-  get_forced_publish_events() const {
-    DRAKE_DEMAND(forced_publish_events_ != nullptr);
-    return *forced_publish_events_;
-  }
-
-  /** (Internal use only) */
-  const EventCollection<DiscreteUpdateEvent<T>>&
-  get_forced_discrete_update_events() const {
-    DRAKE_DEMAND(forced_discrete_update_events_ != nullptr);
-    return *forced_discrete_update_events_;
-  }
-
-  /** (Internal use only) */
-  const EventCollection<UnrestrictedUpdateEvent<T>>&
-  get_forced_unrestricted_update_events() const {
-    DRAKE_DEMAND(forced_unrestricted_update_events_ != nullptr);
-    return *forced_unrestricted_update_events_;
-  }
-
   // Promote these frequently-used methods so users (and tutorial examples)
   // don't need "this->" everywhere when in templated derived classes.
   // All pre-defined ticket methods should be listed here. They are ordered as
@@ -1900,6 +1879,27 @@ class System : public SystemBase {
 
   EventCollection<UnrestrictedUpdateEvent<T>>&
   get_mutable_forced_unrestricted_update_events() {
+    DRAKE_DEMAND(forced_unrestricted_update_events_ != nullptr);
+    return *forced_unrestricted_update_events_;
+  }
+
+  /** (Internal use only) */
+  const EventCollection<PublishEvent<T>>&
+  get_forced_publish_events() const {
+    DRAKE_DEMAND(forced_publish_events_ != nullptr);
+    return *forced_publish_events_;
+  }
+
+  /** (Internal use only) */
+  const EventCollection<DiscreteUpdateEvent<T>>&
+  get_forced_discrete_update_events() const {
+    DRAKE_DEMAND(forced_discrete_update_events_ != nullptr);
+    return *forced_discrete_update_events_;
+  }
+
+  /** (Internal use only) */
+  const EventCollection<UnrestrictedUpdateEvent<T>>&
+  get_forced_unrestricted_update_events() const {
     DRAKE_DEMAND(forced_unrestricted_update_events_ != nullptr);
     return *forced_unrestricted_update_events_;
   }


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/pull/20035.

The piles of integers were very difficult to understand.

Instead, the test instrumentation should record a global list of events, and then we can easily check what was fired in what order.

Here, I've used string to record the events. I don't so much care that its strings in case you want to do something differently, but I do think its critical that there is only one captures the entire trajectory of events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sherm1/drake/5)
<!-- Reviewable:end -->
