### PR TITLE
Rewrite test infra for clarity

### DIFF
--- a/systems/analysis/simulator.h
+++ b/systems/analysis/simulator.h
@@ -562,7 +562,7 @@ class Simulator {
   /// @see LeafSystem::DeclareInitializationPublishEvent()
   /// @see LeafSystem::DeclarePerStepPublishEvent()
   /// @see LeafSystem::DeclareForcedPublishEvent()
- void set_publish_at_initialization(bool publish) {
+  void set_publish_at_initialization(bool publish) {
     publish_at_initialization_ = publish;
   }
 


### PR DESCRIPTION
https://github.com/RobotLocomotion/drake/pull/20035

Use different handler callbacks for distinct trigger types, so that
it's very clear both to someone reading the test code, or in gdb, or
looking at the event log exactly what handler was triggered for what
reason.

Place the full handler details into failed event status messages, so
that it's clear which trigger type caused a failure.

Use an event log instead of piles of obscure integers.

Don't regex-test for unnecessary deatils of the simulator status
message outputs, like the system name or the timestamp. We already
test EXPECT_EQ(sim.get_context().get_time(), early_return_time)
separately, and anything we add to regexes is just a pain in the ass
to keep up to date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sherm1/drake/6)
<!-- Reviewable:end -->
